### PR TITLE
Moved back to 2.0.5b, pull archived mods from modrinth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,14 @@ RUN rm -r /tmp/rcon.tar.gz /tmp/rcon
 RUN mkdir /data
 WORKDIR /data
 RUN curl -fsSL -o "/tmp/pack.zip" "https://www.curseforge.com/api/v1/mods/681792/files/4731348/download"
+RUN curl -fsSL -o "/tmp/old.zip" "https://www.curseforge.com/api/v1/mods/681792/files/4496671/download"
 RUN unzip -q /tmp/pack.zip
-RUN curl -fsSL -o "mods/vinery.jar" "https://cdn.modrinth.com/data/1DWmBJVA/versions/cLYVl6S1/vinery-1.1.4.jar"
-RUN curl -fsSL -o "mods/heph.jar" "https://cdn.modrinth.com/data/sdSn3wvy/versions/hEFa9Ofs/Hephaestus-1.18.2-3.5.2.155.jar"
+RUN unzip -q /tmp/old.zip -d /tmp/old/
+RUN cp /tmp/old/mods/vinery-1.1.4.jar mods/
+RUN cp /tmp/old/mods/Hephaestus-1.18.2-3.5.2.155.jar mods/
 RUN rm /tmp/pack.zip
-
+RUN rm /tmp/old.zip
+RUN rm -rf /tmp/old/
 RUN curl -fsSL -o "server.jar" "https://meta.fabricmc.net/v2/versions/loader/1.18.2/0.14.22/0.11.2/server/jar"
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,10 @@ RUN rm -r /tmp/rcon.tar.gz /tmp/rcon
 
 RUN mkdir /data
 WORKDIR /data
-RUN curl -fsSL -o "/tmp/pack.zip" "https://www.curseforge.com/api/v1/mods/681792/files/4496671/download"
+RUN curl -fsSL -o "/tmp/pack.zip" "https://www.curseforge.com/api/v1/mods/681792/files/4731348/download"
 RUN unzip -q /tmp/pack.zip
+RUN curl -fsSL -o "mods/vinery.jar" "https://cdn.modrinth.com/data/1DWmBJVA/versions/cLYVl6S1/vinery-1.1.4.jar"
+RUN curl -fsSL -o "mods/heph.jar" "https://cdn.modrinth.com/data/sdSn3wvy/versions/hEFa9Ofs/Hephaestus-1.18.2-3.5.2.155.jar"
 RUN rm /tmp/pack.zip
 
 RUN curl -fsSL -o "server.jar" "https://meta.fabricmc.net/v2/versions/loader/1.18.2/0.14.22/0.11.2/server/jar"


### PR DESCRIPTION
Use modrinth to get missing mods.

I haven't done a lot of testing, but this seems to work.