### PR TITLE
Draft: Add support for ARM

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,6 +43,9 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
@@ -73,6 +76,7 @@ jobs:
         id: build-and-push
         uses: docker/build-push-action@v6
         with:
+          platforms: linux/amd64,linux/arm64
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,11 +42,6 @@ jobs:
       - name: Install cosign
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@v3
-      
-      # Setup QEMU to allow building multi-platform images
-      # https://docs.docker.com/build/ci/github-actions/multi-platform/
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,7 +42,9 @@ jobs:
       - name: Install cosign
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@v3
-
+      
+      # Setup QEMU to allow building multi-platform images
+      # https://docs.docker.com/build/ci/github-actions/multi-platform/
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,11 @@ RUN case "$TARGETPLATFORM" in \
     *) echo "Unsupported platform: $TARGETPLATFORM"; exit 1 ;; \
     esac
 
-
 RUN mkdir /tmp/rcon
-RUN tar -xf /tmp/rcon.tar.gz -C /tmp/rcon --strip-components=1
+RUN tar -xf /tmp/rcon.tar.gz -C /tmp/rcon
+
+
+
 
 WORKDIR /data
 RUN curl -fsSL -o "/tmp/pack.zip" "https://www.curseforge.com/api/v1/mods/681792/files/5795941/download"
@@ -31,8 +33,7 @@ RUN cp /tmp/old/mods/Hephaestus-1.18.2-3.5.2.155.jar mods/
 RUN curl -fsSL -o "server.jar" "https://meta.fabricmc.net/v2/versions/loader/1.18.2/0.16.3/0.11.1/server/jar"
 
 FROM eclipse-temurin:17-jre-jammy
-COPY --from=builder --chmod=755 /tmp/rcon/rcon /usr/local/bin/rcon-cli
-COPY --from=builder --chmod=644 /tmp/rcon/rcon.yaml /etc/rcon.yaml
+COPY --from=builder --chmod=755 /tmp/rcon/rcon-cli /usr/local/bin/rcon-cli
 COPY --chmod=755 rcon /usr/local/bin/rcon
 COPY --chmod=755 entrypoint.sh /entrypoint.sh
 

--- a/compose.yml
+++ b/compose.yml
@@ -11,6 +11,7 @@ services:
       - ./banned-players.json:/data/banned-players.json:z
       - ./banned-ips.json:/data/banned-ips.json:z
       - ./server.properties:/init/server.properties:z
+      - ./rcon.yaml:/etc/rcon.yaml:z
       - astral-world:/data/world:z
       - astral-backup:/data/backup:z
 volumes:

--- a/rcon
+++ b/rcon
@@ -1,6 +1,6 @@
 #!/bin/sh
 if [ -n "$RCON_PASSWORD" ]; then
-	rcon-cli -a "localhost:25575" -p "$RCON_PASSWORD" -c "/etc/rcon.yaml" "$@"
+	rcon-cli --host localhost --port 25575 --password "$RCON_PASSWORD"
 else
-	rcon-cli -a "localhost:25575" -c "/etc/rcon.yaml" "$@"
+	rcon-cli --config "/etc/rcon-cli.yaml"
 fi

--- a/rcon.yaml
+++ b/rcon.yaml
@@ -1,0 +1,4 @@
+# Change these as needed for your configuration
+host: localhost
+port: 25575
+password: hunter2


### PR DESCRIPTION
As hosting a minecraft sever on the free Oracle ARM servers is fairly popular, I figured it's worth adding support for that. I have a server of my own on Oracle and have tested this change in my repo, all works well and saves people having to run 
`docker buildx build --platform linux/arm64 -t ghcr.io/maxi0604/create-astral:v2.1 --load .`

Adds very minimal build time since this is a relatively small project so I didn't split the builds, it takes less than 3 minutes total. Let me know if anything else needs to be done. 