### PR TITLE
Create: Astral V2.1.3 version bump + misc. changes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,7 +19,7 @@ env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
-  IMAGE_NAME: maxi0604/create-astral
+  IMAGE_NAME: claraphyll/create-astral
 
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir /tmp/rcon
 RUN tar -xf /tmp/rcon.tar.gz -C /tmp/rcon --strip-components=1
 
 WORKDIR /data
-RUN curl -fsSL -o "/tmp/pack.zip" "https://www.curseforge.com/api/v1/mods/681792/files/5864156/download"
+RUN curl -fsSL -o "/tmp/pack.zip" "https://www.curseforge.com/api/v1/mods/681792/files/6057416/download"
 RUN curl -fsSL -o "/tmp/old.zip" "https://www.curseforge.com/api/v1/mods/681792/files/4496671/download"
 RUN unzip -q /tmp/pack.zip -d /data
 RUN unzip -q /tmp/old.zip -d /tmp/old/

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ podman run -d -e EULA=TRUE \
   -v ./banned-ips.json:/data/banned-ips.json:z \
   -v astral-world:/data/world:z \
   -v astral-backup:/data/backup:z \
-  ghcr.io/maxi0604/create-astral:v2.1.2
+  ghcr.io/claraphyll/create-astral:v2.1.3
 ```
 to get started. This will run a Create: Astral server on port 25565 (the default) which stores the game world in a named volume.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ you run your compose command. The required templates for these files are include
 If you want to modify other files like those in the `config` folder, consider adding the
 `/data/config` folder as a volume similar to how the files above are set up.
 
+## JVM Arguments (memory usage)
+
+If you are building the image yourself, you can customize the JVM arguments used by the server in [`entrypoint.sh`](entrypoint.sh).
+
 #  Manual Setup
 The server can be set up without using a program like `podman-compose` or `docker-compose`.
 
@@ -56,6 +60,15 @@ podman run -d -e EULA=TRUE \
   ghcr.io/claraphyll/create-astral:v2.1.3
 ```
 to get started. This will run a Create: Astral server on port 25565 (the default) which stores the game world in a named volume.
+
+## Building your own image
+
+If you use compose, you can have the best of both worlds with very little modification. Replace the `image: ghcr.io/claraphyll/create-astral:v2.1.3` line in the [`compose.yaml`](compose.yaml) file with the following:
+```yaml
+build: .
+```
+
+Now, when you run the command `podman-compose build` or `docker compose build` you will be able to build the image using the provided Dockerfile. This can allow you to modify your [`entrypoint.sh`](entrypoint.sh) or perform any other customizations, such as updating to an as of yet unsupported version of Create: Astral. Once it is built, you can run the container like normal using `docker compose up -d` or `podman-compose up -d`.
 
 # Maintenance
 See the documentation for your preferred container engine for comprehensive guidance. Some hints:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ to get started. This will run a Create: Astral server on port 25565 (the default
 
 ## Building your own image
 
-If you use compose, you can have the best of both worlds with very little modification. Replace the `image: ghcr.io/claraphyll/create-astral:v2.1.3` line in the [`compose.yaml`](compose.yaml) file with the following:
+If you use compose, you can have the best of both worlds with very little modification. Replace the line `image: ghcr.io/claraphyll/create-astral:v2.1.3` in the [`compose.yaml`](compose.yaml) file with the following:
 ```yaml
 build: .
 ```

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   create-astral:
-    image: ghcr.io/maxi0604/create-astral:v2.1.2
+    image: ghcr.io/claraphyll/create-astral:v2.1.3
     environment:
         EULA: "FALSE"
         RCON_PASSWORD: "hunter2"


### PR DESCRIPTION
Hello!

I've done a few things in this PR, so feel free to ask me to separate them out into different ones so that you can pick and choose some of the changes in particular. Let me know!

Here's what I've done:

- Updated `Dockerfile` to download the latest version of the Create: Astral server pack. I changed the file ID from `5864156` to `6057416`.
  - Old: https://www.curseforge.com/api/v1/mods/681792/files/5864156
  - New: https://www.curseforge.com/api/v1/mods/681792/files/6057416
- I've updated all the references I could find of the container image since its path appears to have changed due to a name change by @claraphyll (let me know if I'm mistaken).
- I updated `README.md` to reference the most recent version of Create: Astral.
- I've also added some information to `README.md` about how people can build the container themselves using compose rather than download it from the container registry. I also added a brief explanation about how people can use this to modify things like the JVM arguments.
  - Some of the context behind why I added this to the README is because I was confused why the container wasn't starting up for me, and the reason ended up being because the machine I was attempting it on couldn't free 6gb of memory to allocate to the JVM. I needed to modify `entrypoint.sh` to slightly reduce the amount of memory allocated (and it worked).
  - It may be worth considering adding an environment variable to `compose.yaml` to allow for easier control over the amount of memory the user wants to allocate to the server.